### PR TITLE
TRITON-1140 convert triton-mockcloud to engbld framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /tmp
+/make_stamps
 /node_modules
 /make_stamps
 /npm-debug.log
-/mockcloud-pkg-*.tar.bz2
+/mockcloud-pkg-*.tar.gz
+/bits
 /build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/eng"]
+	path = deps/eng
+	url = https://github.com/joyent/eng.git

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, Joyent, Inc.
+# Copyright (c) 2019, Joyent, Inc.
 #
 
 NAME=mockcloud
@@ -29,21 +29,35 @@ endif
 #
 # Included definitions
 #
-include ./tools/mk/Makefile.defs
-include ./tools/mk/Makefile.node_modules.defs
+
+# triton-mockcloud is not a public module, so override
+ENGBLD_DEST_OUT_PATH ?= /stor/builds
+
+ENGBLD_USE_BUILDIMAGE	= true
+ENGBLD_REQUIRE		:= $(shell git submodule update --init deps/eng)
+include ./deps/eng/tools/mk/Makefile.defs
+TOP ?= $(error Unable to access eng.git submodule Makefiles.)
+
+include ./deps/eng/tools/mk/Makefile.node_modules.defs
 ifeq ($(shell uname -s),SunOS)
-	include ./tools/mk/Makefile.node_prebuilt.defs
+	include ./deps/eng/tools/mk/Makefile.node_prebuilt.defs
+	include ./deps/eng/tools/mk/Makefile.agent_prebuilt.defs
 else
 	NODE_EXEC := $(shell which node)
 	NODE = node
 	NPM_EXEC := $(shell which npm)
 	NPM = npm
 endif
-include ./tools/mk/Makefile.smf.defs
+include ./deps/eng/tools/mk/Makefile.smf.defs
 
-RELEASE_TARBALL = $(NAME)-pkg-$(STAMP).tar.bz2
-RELSTAGEDIR := /tmp/$(STAMP)
+RELEASE_TARBALL = $(NAME)-pkg-$(STAMP).tar.gz
+RELSTAGEDIR := /tmp/$(NAME)-$(STAMP)
 
+BASE_IMAGE_UUID = 1ad363ec-3b83-11e8-8521-2f68a4a34d5d
+BUILDIMAGE_NAME = $(NAME)
+BUILDIMAGE_DESC	= SDC MOCK CLOUD
+BUILDIMAGE_PKGSRC = tftp-hpa-5.2
+AGENTS		= amon config registrar
 
 #
 # Repo-specific targets
@@ -90,25 +104,22 @@ release: all
 		$(RELSTAGEDIR)/root/opt/triton/$(NAME)/build/node/include \
 		$(RELSTAGEDIR)/root/opt/triton/$(NAME)/build/node/share
 	# Tar it up.
-	(cd $(RELSTAGEDIR) && $(TAR) -jcf $(TOP)/$(RELEASE_TARBALL) root)
+	(cd $(RELSTAGEDIR) && $(TAR) -I pigz -cf $(TOP)/$(RELEASE_TARBALL) root)
 	@rm -rf $(RELSTAGEDIR)
 
-publish:
-	@if [[ -z "$(BITS_DIR)" ]]; then \
-		echo "error: 'BITS_DIR' must be set for 'publish' target"; \
-		exit 1; \
-	fi
-	mkdir -p $(BITS_DIR)/$(NAME)
-	cp $(RELEASE_TARBALL) $(BITS_DIR)/$(NAME)/$(RELEASE_TARBALL)
+publish: release
+	mkdir -p $(ENGBLD_BITS_DIR)/$(NAME)
+	cp $(RELEASE_TARBALL) $(ENGBLD_BITS_DIR)/$(NAME)/$(RELEASE_TARBALL)
 
 
 #
 # Includes
 #
-include ./tools/mk/Makefile.deps
-include ./tools/mk/Makefile.node_modules.targ
+include ./deps/eng/tools/mk/Makefile.deps
+include ./deps/eng/tools/mk/Makefile.node_modules.targ
 ifeq ($(shell uname -s),SunOS)
-	include ./tools/mk/Makefile.node_prebuilt.targ
+	include ./deps/eng/tools/mk/Makefile.node_prebuilt.targ
+	include ./deps/eng/tools/mk/Makefile.agent_prebuilt.targ
 endif
-include ./tools/mk/Makefile.smf.targ
-include ./tools/mk/Makefile.targ
+include ./deps/eng/tools/mk/Makefile.smf.targ
+include ./deps/eng/tools/mk/Makefile.targ

--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,9 @@ include ./deps/eng/tools/mk/Makefile.smf.defs
 RELEASE_TARBALL = $(NAME)-pkg-$(STAMP).tar.gz
 RELSTAGEDIR := /tmp/$(NAME)-$(STAMP)
 
-BASE_IMAGE_UUID = 1ad363ec-3b83-11e8-8521-2f68a4a34d5d
+BASE_IMAGE_UUID = b6ea7cb4-6b90-48c0-99e7-1d34c2895248
 BUILDIMAGE_NAME = $(NAME)
-BUILDIMAGE_DESC	= SDC MOCK CLOUD
-BUILDIMAGE_PKGSRC = tftp-hpa-5.2
-AGENTS		= amon config registrar
+BUILDIMAGE_DESC	= Triton Mockcloud
 
 #
 # Repo-specific targets


### PR DESCRIPTION
This change shouldn't be merged until the corresponding MG changes for TOOLS-2171 go back (though those are only necessary _if_ for some reason we don't update the jenkins job to build the component directory, removing the use of MG)